### PR TITLE
chore: widen requires-python to support Python 3.14+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ keywords = [
 license = {text = "MIT"}
 name = "debug-toolbar"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 version = "0.4.2"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Remove upper bound (`<3.14`) from `requires-python`, changing it to `>=3.10`
- Enables installation on Python 3.14+

Closes #42

## Test plan

- [x] Full test suite passes on Python 3.12 (642 passed, 5 skipped)
- [x] Full test suite passes on Python 3.14 (642 passed, 5 skipped)
- [ ] CI confirmation